### PR TITLE
Modify gh action to execute via docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG GO_VERSION=1.18-alpine3.15
 ARG FROM_IMAGE=alpine:3.15
 
+# Builder stage
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS builder
 
 ARG TARGETOS
@@ -14,15 +15,20 @@ WORKDIR /app
 COPY ./ /app
 
 RUN apk update && \
-  apk add ca-certificates gettext git make curl unzip && \
-  rm -rf /tmp/* && \
-  rm -rf /var/cache/apk/* && \
-  rm -rf /var/tmp/*
+    apk add --no-cache ca-certificates gettext git make curl unzip && \
+    rm -rf /tmp/* && \
+    rm -rf /var/cache/apk/* && \
+    rm -rf /var/tmp/* && \
+    make build TARGETOS=$TARGETOS TARGETARCH=$TARGETARCH VERSION=$VERSION
 
-RUN make build TARGETOS=$TARGETOS TARGETARCH=$TARGETARCH VERSION=$VERSION
-
+# Final stage
 FROM ${FROM_IMAGE}
 
+# Ensure ca-certificates are present in the final image
+RUN apk add --no-cache ca-certificates
+
+# Copy the built binary from the builder stage
 COPY --from=builder /app/dist/argocd-actions /bin/argocd-actions
 
+# Set the entry point
 ENTRYPOINT ["argocd-actions"]

--- a/action.yml
+++ b/action.yml
@@ -26,15 +26,5 @@ inputs:
     required: false
 
 runs:
-  using: "composite"
-  steps:
-    - name: Run argocd-actions CLI from the image for GH image registry
-      run: |
-        docker run --rm -i ghcr.io/cheelim1/argocd-actions:${{ inputs.image }} \
-          ${{ inputs.action }} \
-          --application=${{ inputs.application }} \
-          --labels=${{ inputs.labels }} \
-          --token=${{ inputs.token }} \
-          --address=${{ inputs.address }} \
-          --logLevel=debug
-      shell: sh
+  using: 'docker'
+  image: 'Dockerfile'

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -15,13 +16,13 @@ func Root() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	cmd.PersistentFlags().String("address", "", "ArgoCD address")
+	cmd.PersistentFlags().String("address", os.Getenv("INPUT_ADDRESS"), "ArgoCD address")
 
 	if err := cmd.MarkPersistentFlagRequired("address"); err != nil {
 		log.Fatalf("Lethal damage: %s\n\n", err)
 	}
 
-	cmd.PersistentFlags().String("token", "", "ArgoCD token")
+	cmd.PersistentFlags().String("token", os.Getenv("INPUT_TOKEN"), "ArgoCD token")
 
 	if err := cmd.MarkPersistentFlagRequired("token"); err != nil {
 		log.Fatalf("Lethal damage: %s\n\n", err)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -55,8 +56,10 @@ func Sync() *cobra.Command {
             return nil
         },
     }
-
-    cmd.Flags().String("application", "", "ArgoCD application name")
-    cmd.Flags().String("labels", "", "Labels to sync the ArgoCD app with")  // Add the new flag for labels
+    
+    cmd.Flags().String("address", os.Getenv("INPUT_ADDRESS"), "ArgoCD server address")
+    cmd.Flags().String("token", os.Getenv("INPUT_TOKEN"), "ArgoCD token")
+    cmd.Flags().String("application", os.Getenv("INPUT_APPLICATION"), "ArgoCD application name")
+    cmd.Flags().String("labels", os.Getenv("INPUT_LABELS"), "Labels to sync the ArgoCD app with")  // Add the new flag for labels
     return cmd
 }

--- a/internal/argocd/api.go
+++ b/internal/argocd/api.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
 	"strings"
 	"time"
 
@@ -44,6 +45,14 @@ type APIOptions struct {
 
 // NewAPI creates new API.
 func NewAPI(options *APIOptions) API {
+    if options.Address == "" {
+        options.Address = os.Getenv("INPUT_ADDRESS")
+    }
+    if options.Token == "" {
+        options.Token = os.Getenv("INPUT_TOKEN")
+    }
+    
+    
 	clientOptions := argocdclient.ClientOptions{
 		ServerAddr: options.Address,
 		AuthToken:  options.Token,


### PR DESCRIPTION
Title: Use environment variables as fallback for API options

Description:
- Modified the NewAPI function in api.go to use environment variables (INPUT_ADDRESS and INPUT_TOKEN) as default values for the Address and Token fields.
- This change ensures that if Address and Token are not provided when calling NewAPI, the function will fall back to using the values from the environment variables.
- This provides flexibility for the function's usage, allowing it to be called with explicit values or rely on the environment.
